### PR TITLE
chore(sigma-protocols): remove details for simulate_response

### DIFF
--- a/draft-irtf-cfrg-sigma-protocols.md
+++ b/draft-irtf-cfrg-sigma-protocols.md
@@ -137,7 +137,7 @@ Where:
 
 The final two algorithms describe the **zero-knowledge simulator**. In particular, they may be used for proof composition (e.g. OR-composition). The function `simulate_commitment` is also used when verifying short proofs. We have:
 
-- `simulate_response(self, rng) -> response`, denoting the first stage of the simulator. It is an algorithm drawing a random response given a specified cryptographically secure RNG that follows the same output distribution of the algorithm `prover_response`.
+- `simulate_response(self, rng) -> response`, denoting the first stage of the simulator.
 
 - `simulate_commitment(self, response, challenge) -> commitment`, returning a simulated commitment -- the second phase of the zero-knowledge simulator.
 


### PR DESCRIPTION
From #67:
7. For simulate_response you write "It is an algorithm drawing a random response given a specified cryptographically secure RNG that follows the same output distribution of the algorithm prover_response." I would omit this, since you do not discuss security properties of any of the other algorithms here (and, in particular, you do not say anything about the output distribution of simulate_commitment).