### PR TITLE
chore(sigma-protocols): fix map output

### DIFF
--- a/draft-irtf-cfrg-sigma-protocols.md
+++ b/draft-irtf-cfrg-sigma-protocols.md
@@ -304,7 +304,7 @@ The linear map `LinearMap` is initialized with
 
 #### Linear map evaluation
 
-A witness can be mapped to a group element via:
+A witness can be mapped to a vector of group elements via:
 
     map(self, scalars: [Scalar; num_scalars])
 


### PR DESCRIPTION
From #69:
Section 2.2.5.2: "A witness can be mapped to a group element" should be "A witness can be mapped to a vector of group elements."