### PR TITLE
Rename nonces to blindings

### DIFF
--- a/draft-irtf-cfrg-sigma-protocols.md
+++ b/draft-irtf-cfrg-sigma-protocols.md
@@ -221,9 +221,9 @@ The prover of a sigma protocol is stateful and will send two messages, a "commit
 
     Procedure:
 
-    1. nonces = [self.instance.Domain.random(rng) for _ in range(self.instance.linear_map.num_scalars)]
-    2. prover_state = self.ProverState(witness, nonces)
-    3. commitment = self.instance.linear_map(nonces)
+    1. blindings = [self.instance.Domain.random(rng) for _ in range(self.instance.linear_map.num_scalars)]
+    2. prover_state = self.ProverState(witness, blindings)
+    3. commitment = self.instance.linear_map(blindings)
     4. return (prover_state, commitment)
 
 #### Prover response
@@ -241,8 +241,8 @@ The prover of a sigma protocol is stateful and will send two messages, a "commit
 
     Procedure:
 
-    1. witness, nonces = prover_state
-    2. return [nonces[i] + witness[i] * challenge for i in range(self.instance.linear_map.num_scalars)]
+    1. witness, blindings = prover_state
+    2. return [blindings[i] + witness[i] * challenge for i in range(self.instance.linear_map.num_scalars)]
 
 ### Verifier
 

--- a/poc/sigma_protocols.sage
+++ b/poc/sigma_protocols.sage
@@ -58,21 +58,21 @@ class SchnorrProof(SigmaProtocol):
     """
     A sigma protocol for simple linear relations.
     """
-    ProverState = namedtuple("ProverState", ["witness", "nonces"])
+    ProverState = namedtuple("ProverState", ["witness", "blindings"])
 
     def __init__(self, instance):
         self.instance = instance
 
     def prover_commit(self, witness, rng):
-        nonces = [self.instance.Domain.random(rng) for _ in range(self.instance.linear_map.num_scalars)]
-        prover_state = self.ProverState(witness, nonces)
-        commitment = self.instance.linear_map(nonces)
+        blindings = [self.instance.Domain.random(rng) for _ in range(self.instance.linear_map.num_scalars)]
+        prover_state = self.ProverState(witness, blindings)
+        commitment = self.instance.linear_map(blindings)
         return (prover_state, commitment)
 
     def prover_response(self, prover_state: ProverState, challenge):
-        witness, nonces = prover_state
+        witness, blindings = prover_state
         return [
-            nonces[i] + witness[i] * challenge
+            blindings[i] + witness[i] * challenge
             for i in range(self.instance.linear_map.num_scalars)
         ]
 


### PR DESCRIPTION
Editorial: rename "nonces" (which is a confusing term, they should be random but don't have to be nonces) to "blindings" which is what we called it in the proof compiler in ARC, and is the generally-accepted term for the random scalar used to blind a commitment.

Closes #75 