### PR TITLE
Properly introduce LinearRelation

### DIFF
--- a/draft-irtf-cfrg-sigma-protocols.md
+++ b/draft-irtf-cfrg-sigma-protocols.md
@@ -328,7 +328,6 @@ Group elements, being part of the instance, can later be set using the function 
     2. self.linear_map.append(linear_combination)
     3. self._image.append(lhs)
 
-
 ### Core protocol
 
 This defines the object `SchnorrProof`. The initialization function takes as input the statement, and pre-processes it.


### PR DESCRIPTION
Fixes #110, and an editorial note from #69:

> It will be helpful to define `LinearRelation` before it is first used.

> Define terminology (e.g., LinearRelation is referenced without definition).

> The terms linear_map, num_scalars, and num_constraints are not defined
> until Section 2.2.4 and beyond.
> It would help to set up this notation earlier as part of defining a linear map.