### PR TITLE
Constant time consideration section

### DIFF
--- a/draft-irtf-cfrg-sigma-protocols.md
+++ b/draft-irtf-cfrg-sigma-protocols.md
@@ -478,7 +478,7 @@ The non-interactive Fiat-Shamir transformation leads to publicly verifiable (tra
 
 ## Constant-Time Requirements
 
-The prover's control flow and memory access patterns are typically influenced by the witness. 
+The prover's control flow and memory access patterns are typically influenced by the witness.
 To prevent side-channel leakage of witness information, which may reveal private values, it is important that the implementation of underlying group and field operations are constant-time. Operations such as modular reduction, scalar multiplication, random value generation, and all other group and field operations are required to be constant-time especially when working with inputs which are private to prevent side-channel attacks which may reveal their values. In some cases, such as keyed-verification credentials, also the verifier must be constant-time.
 
 # Post-Quantum Security Considerations


### PR DESCRIPTION
Added a couple sentences in the security section about constant-time. Requires knowing that there are constant-time algorithms for various group/field operations:

- Scalar multiplication requires a constant-time selector function, such as: https://docs.rs/subtle/latest/subtle/trait.ConditionallySelectable.html and should loop through all `n` bits where (`n` is the size of the field) regardless of if the scalar is a smaller number of bits.
- Modular reduction: Barrett Reduction (https://en.wikipedia.org/wiki/Barrett_reduction) requires bit shifts by a pre-selected constant amount, preventing input-dependent runtime
- Random nonce generation: Can use `dev/urandom` which uses ChaCha20 (inherently not input dependent because it just uses bitwise operations and rotations)
- Hash-to-curve: https://eprint.iacr.org/2019/403

Looking at our Rust implementation, we use `curve25519-dalek` crate's Ristretto point and the `bls12_381` crate's G1 group. 

- Both use a constant-time comparison function `ct_eq` for `bls12_381` and `conditional_select` for Ristretto
