### PR TITLE
Fixes execution of poc sage code.

### DIFF
--- a/poc/groups/groups.sage
+++ b/poc/groups/groups.sage
@@ -13,11 +13,14 @@ from sagelib.suite_p521 import p521_sswu_ro, p521_order, p521_p, p521_F, p521_A,
 from sagelib.common import sgn0
 from sagelib.ristretto_decaf import Ed25519Point, Ed448GoldilocksPoint
 
+def byte_length(x):
+    return (len(x.bits()) + 7) // 8
+
 class Scalar(ABC):
     def __new__(cls, order, *args, **kwargs):
         cls.field = GF(order)  # Delegate field operations to GF instance
         cls.order = order
-        cls.field_bytes_length = (order.bit_length() + 7) // 8
+        cls.field_bytes_length = byte_length(order)
         return cls
 
     def __getattr__(self, name):
@@ -108,7 +111,7 @@ class Group(ABC):
 
     @classmethod
     def random(cls, rng):
-        return cls.generator() * cls.ScalarField.random(rng)
+        return cls.scalar_mult(cls.ScalarField.random(rng), cls.generator())
 
     @classmethod
     def msm(cls, scalars, points):
@@ -219,7 +222,7 @@ class GroupNISTCurve(Group):
 
     @classmethod
     def scalar_mult(cls, x, y):
-        return x * y
+        return x.lift() * y
 
     def vec_scalar_mult(self, scalar, points):
         return [point * scalar for point in points]
@@ -496,8 +499,8 @@ class BLS12_381_G1(Group):
 
     @classmethod
     def element_byte_length(cls):
-        return (cls.Fq.order().bit_length() + 7) // 8
+        return byte_length(cls.Fq.order())
 
     @classmethod
     def scalar_mult(cls, x, y):
-        return y * x
+        return x.lift() * y

--- a/poc/sigma_protocols.sage
+++ b/poc/sigma_protocols.sage
@@ -155,7 +155,7 @@ class LinearMap:
     def __call__(self, scalars):
         image = []
         for linear_combination in self.linear_combinations:
-            coefficients = [scalars[i]
+            coefficients = [self.Group.ScalarField.field(scalars[i])
                             for i in linear_combination.scalar_indices]
             elements = [self.group_elements[i]
                         for i in linear_combination.element_indices]

--- a/poc/test_sigma_protocols.sage
+++ b/poc/test_sigma_protocols.sage
@@ -82,7 +82,7 @@ def discrete_logarithm(rng, group):
     statement.set_elements([(var_G, G)])
 
     x = group.ScalarField.random(rng)
-    X = G * x
+    X = group.scalar_mult(x, G)
     assert [X] == statement.linear_map([x])
 
     statement.set_elements([(var_X, X)])
@@ -100,8 +100,8 @@ def dleq(rng, group):
     G = group.generator()
     H = group.random(rng)
     x = group.ScalarField.random(rng)
-    X = G * x
-    Y = H * x
+    X = group.scalar_mult(x, G)
+    Y = group.scalar_mult(x, H)
 
     statement = LinearRelation(group)
     [var_x] = statement.allocate_scalars(1)
@@ -128,7 +128,7 @@ def pedersen_commitment(rng, group):
     r = group.ScalarField.random(rng)
     witness = [x, r]
 
-    C = G * x + H * r
+    C = group.scalar_mult(x, G) + group.scalar_mult(r, H)
     statement = LinearRelation(group)
     [var_x, var_r] = statement.allocate_scalars(2)
     [var_G, var_H, var_C] = statement.allocate_elements(3)
@@ -189,7 +189,10 @@ def bbs_blind_commitment_computation(rng, group):
 
     # these are computed before the proof in the specification
     secret_prover_blind = group.ScalarField.random(rng)
-    C = secret_prover_blind * Q_2 + msg_1 * J_1 + msg_2 * J_2 + msg_3 * J_3
+    C = group.scalar_mult(secret_prover_blind, Q_2) + \
+        group.scalar_mult(msg_1, J_1) + \
+        group.scalar_mult(msg_2, J_2) + \
+        group.scalar_mult(msg_3, J_3)
 
     # This is the part that needs to be changed in the specification of blind bbs.
     statement = LinearRelation(group)


### PR DESCRIPTION
This works ok with SageMath version 9.5.

The issue is that scalars are represented as Class instances.
For scalar multiplication, group elements expect an integer as scalar, not an object.

calling explictly the scalar_mult method is an easy fix.

