### PR TITLE
doc(poc/sigma_protocols): clarify purpose of POC impl

### DIFF
--- a/poc/sigma_protocols.sage
+++ b/poc/sigma_protocols.sage
@@ -4,8 +4,9 @@ Proof-of-concept implementation for the CFRG Internet-Draft
 
 This code is an example implementation for specification discussion and test
 vector generation; it is not intended for production deployment.
-No guarantees are provided for constant-time behavior, side-channel resistance,
-or secure cleanup/erasure of sensitive intermediate data.
+Side-channel security is not provided in this PoC (including constant-time
+execution and secure deletion of sensitive data).
+See `draft-irtf-cfrg-sigma-protocols`, Section "Security Considerations", for more information.
 """
 
 from abc import ABC, abstractmethod


### PR DESCRIPTION
This + #120 should be enough to close the security review feedback on constant-time requirements