### PR TITLE
Update CSRNG API snippet in sigma spec

### DIFF
--- a/draft-irtf-cfrg-sigma-protocols.md
+++ b/draft-irtf-cfrg-sigma-protocols.md
@@ -32,7 +32,7 @@ informative:
   fiat-shamir:
     title: "draft-irtf-cfrg-fiat-shamir"
     date: false
-    target: https://mmaker.github.io/spfs/draft-irtf-cfrg-fiat-shamir.html
+    target: https://mmaker.github.io/draft-irtf-cfrg-sigma-protocols/draft-irtf-cfrg-fiat-shamir.html
   SP800:
     title: "Recommendations for Discrete Logarithm-based Cryptography"
     target: https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-186.pdf
@@ -171,9 +171,11 @@ non-zero scalars uniformly at random.
 Algorithms access this functionality through the following interface.
 
     class CSRNG(ABC):
-        def random_scalar(self) -> groups.Scalar:
+        def getrandom(self, length: int) -> bytes:
             pass
 
+        def random_scalar(self) -> groups.Scalar:
+            pass
 
 Implementations MUST use a cryptographically secure pseudorandom number
 generator (CSPRNG) to sample non-zero scalars either by using rejection

--- a/draft-irtf-cfrg-sigma-protocols.md
+++ b/draft-irtf-cfrg-sigma-protocols.md
@@ -171,7 +171,7 @@ non-zero scalars uniformly at random.
 Algorithms access this functionality through the following interface.
 
     class CSRNG(ABC):
-        def getrandom(length: int) -> bytes:
+        def random_scalar(self) -> groups.Scalar:
             pass
 
 


### PR DESCRIPTION
The spec's CSRNG API wasn't updated when we updated the POC. Thanks for the catch @armfazh!

This also fixes a broken link for the fiat-shamir spec.

Note, the poc requires the CSRNG to also have a `getrandom()` function... but that is not used anywhere by sigma/f-s. I'll copy that into the spec, so the spec and poc are in line, but we can potentially remove this (from both the spec and poc) in a future clean-up pass.